### PR TITLE
Fix: Wig model price is stored in pennies, and added a custom getter …

### DIFF
--- a/server/db/models/wig.js
+++ b/server/db/models/wig.js
@@ -16,8 +16,11 @@ const Wig = db.define('wig', {
     allowNull: false
   },
   price: {
-    type: Sequelize.FLOAT,
-    allowNull: false
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    get() {
+      return this.getDataValue('price') / 100;
+    }
   },
   quantity: {
     type: Sequelize.INTEGER,


### PR DESCRIPTION
…on price to divide by 100

### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

Wig model price in pennies, added custom getter to divide price by 100
